### PR TITLE
Hidden content in relation

### DIFF
--- a/components/ExtraBundle/bundle/Twig/ContentExtension.php
+++ b/components/ExtraBundle/bundle/Twig/ContentExtension.php
@@ -75,6 +75,9 @@ class ContentExtension extends AbstractExtension
         try {
             $content = $this->repository->getContentService()->loadContent($fieldValue->destinationContentId);
 
+            if (true === $content->contentInfo->isHidden) {
+                return false;
+            }
             if (!$content->contentInfo->isTrashed()) {
                 $locationService = $this->repository->getLocationService();
                 $location = $locationService->loadLocation($content->contentInfo->mainLocationId);
@@ -97,6 +100,10 @@ class ContentExtension extends AbstractExtension
         foreach ($fieldValue->destinationContentIds as $id) {
             try {
                 $content = $repository->getContentService()->loadContent($id);
+
+                if (true === $content->contentInfo->isHidden) {
+                    continue;
+                }
                 if (!$content->contentInfo->isTrashed()) {
                     $location = $repository->getLocationService()->loadLocation($content->contentInfo->mainLocationId);
                     if ($location->invisible || $location->hidden) {


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no (from 2.5.x when content.hidden has been added)

When a content is hidden, make sure it will not be returned by 'eznova_relation_field_to_content' and 'eznova_relationlist_field_to_content_list'
`content->contentInfo->isHidden` will be true if content itself is Hidden
