### PR TITLE
Fix missing parameters

### DIFF
--- a/components/EnhancedImageAssetBundle/src/lib/Imagine/Filter/FilterConfiguration.php
+++ b/components/EnhancedImageAssetBundle/src/lib/Imagine/Filter/FilterConfiguration.php
@@ -51,12 +51,12 @@ class FilterConfiguration extends BaseFilterConfiguration
         $config = $this->filterConfiguration->get($filter);
 
         $optionsResolver = new OptionsResolver();
-        $optionsResolver->setDefaults([
-                                           'quality' => 70,
-                                           'jpeg_quality' => 70,
-                                           'webp_quality' => 70,
-                                           'png_compression_level' => 6,
-                                       ]);
+        $optionsResolver->setDefaults(array_merge([
+            'quality' => 70,
+            'jpeg_quality' => 70,
+            'webp_quality' => 70,
+            'png_compression_level' => 6,
+        ], $config));
 
         $config = $optionsResolver->resolve($config);
 


### PR DESCRIPTION
# Psychologies #96954 - Implémentation des variations d'images (Webp et Jpeg)
https://almaviacx.easyredmine.com/issues/96954

> An exception has been thrown during the rendering of a template ("The options "cache", "data_loader", "filters", "post_processors", "reference" do not exist. Defined options are: "jpeg_quality", "png_compression_level", "quality", "webp_quality".") in "@psychologies/enhanced_image_asset/content_fields.html.twig".


