### PR TITLE
SEO Bundle: integrate meta information into ezplatform/ibexa graphql endpoints

### DIFF
--- a/components/SEOBundle/bundle/Core/SiteAccessAwareEntityManagerFactory.php
+++ b/components/SEOBundle/bundle/Core/SiteAccessAwareEntityManagerFactory.php
@@ -13,6 +13,7 @@
 namespace Novactive\Bundle\eZSEOBundle\Core;
 
 use Doctrine\Bundle\DoctrineBundle\Mapping\ContainerEntityListenerResolver;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
@@ -20,7 +21,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
 use Doctrine\Persistence\ManagerRegistry as Registry;
 use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class SiteAccessAwareEntityManagerFactory
 {

--- a/components/SEOBundle/bundle/DependencyInjection/Compiler/CustomFallbackPass.php
+++ b/components/SEOBundle/bundle/DependencyInjection/Compiler/CustomFallbackPass.php
@@ -12,7 +12,7 @@
 
 namespace Novactive\Bundle\eZSEOBundle\DependencyInjection\Compiler;
 
-use Novactive\Bundle\eZSEOBundle\Twig\NovaeZSEOExtension;
+use Novactive\Bundle\eZSEOBundle\Service\MetaCompositionService;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -27,7 +27,7 @@ class CustomFallbackPass implements CompilerPassInterface
         if (isset($configs[0]['system']['default']['custom_fallback_service'])) {
             $fallbackService = $configs[0]['system']['default']['custom_fallback_service'];
             if (null !== $fallbackService) {
-                $container->getDefinition(NovaeZSEOExtension::class)->addMethodCall(
+                $container->getDefinition(MetaCompositionService::class)->addMethodCall(
                     'setCustomFallbackService',
                     [new Reference($fallbackService)]
                 );

--- a/components/SEOBundle/bundle/DependencyInjection/NovaeZSEOExtension.php
+++ b/components/SEOBundle/bundle/DependencyInjection/NovaeZSEOExtension.php
@@ -55,6 +55,7 @@ class NovaeZSEOExtension extends Extension implements PrependExtensionInterface
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+        $loader->load('graphql.yml');
         $loader->load('services_nonautowired.yml');
         $loader->load('default_settings.yml');
         $loader->load('admin_ui/services.yml');

--- a/components/SEOBundle/bundle/GraphQL/Helper/NameHelper.php
+++ b/components/SEOBundle/bundle/GraphQL/Helper/NameHelper.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Novactive\Bundle\eZSEOBundle\GraphQL\Helper;
+
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+
+class NameHelper
+{
+    private CamelCaseToSnakeCaseNameConverter $caseConverter;
+
+    /**
+     * @param CamelCaseToSnakeCaseNameConverter $caseConverter
+     */
+    public function __construct(CamelCaseToSnakeCaseNameConverter $caseConverter)
+    {
+        $this->caseConverter = $caseConverter;
+    }
+
+    public function sanitizeMetaFieldName(string $metaFieldName)
+    {
+        $sanitizedFieldName = preg_replace("/[-\.:]/", "_", $metaFieldName);
+
+        return $this->caseConverter->denormalize($sanitizedFieldName);
+    }
+}

--- a/components/SEOBundle/bundle/GraphQL/Resolver/NovaEZSeoFieldResolver.php
+++ b/components/SEOBundle/bundle/GraphQL/Resolver/NovaEZSeoFieldResolver.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Novactive\Bundle\eZSEOBundle\GraphQL\Resolver;
+
+use eZ\Publish\API\Repository\Values\Content\Content;
+use GraphQL\Type\Definition\ResolveInfo;
+use Novactive\Bundle\eZSEOBundle\Core\Meta;
+use Novactive\Bundle\eZSEOBundle\GraphQL\Helper\NameHelper;
+use Novactive\Bundle\eZSEOBundle\Service\MetaCompositionService;
+use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+
+class NovaEZSeoFieldResolver implements ResolverInterface, AliasedInterface
+{
+    protected MetaCompositionService $metaCompositionService;
+
+    protected NameHelper $nameHelper;
+
+    public function __construct(MetaCompositionService $metaCompositionService, NameHelper $nameHelper)
+    {
+        $this->metaCompositionService = $metaCompositionService;
+        $this->nameHelper = $nameHelper;
+    }
+
+    public function resolveMetasFieldValue(Content $content, string $fieldDefinitionIdentifier)
+    {
+        $field = $content->getField($fieldDefinitionIdentifier);
+        $metaValues = $this->metaCompositionService->computeMetasUsingFallback($field, $content);
+
+        $output = [];
+
+        /**
+         * @var $metaObject Meta
+         */
+        foreach($metaValues as $definedMetaName => $metaObject)
+        {
+            $output[$this->nameHelper->sanitizeMetaFieldName($definedMetaName)] = $metaObject->getContent();
+        }
+
+        return $output;
+    }
+
+    public static function getAliases()
+    {
+        return [
+            'resolveMetasFieldValue' => 'NovaSeoMetasFieldValue'
+        ];
+    }
+}

--- a/components/SEOBundle/bundle/GraphQL/Schema/Domain/Content/Mapper/FieldDefinition/NovaeZSEOFieldDefinitionMapper.php
+++ b/components/SEOBundle/bundle/GraphQL/Schema/Domain/Content/Mapper/FieldDefinition/NovaeZSEOFieldDefinitionMapper.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Novactive\Bundle\eZSEOBundle\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition;
+
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\DecoratingFieldDefinitionMapper;
+use EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper;
+
+class NovaeZSEOFieldDefinitionMapper extends DecoratingFieldDefinitionMapper implements FieldDefinitionMapper
+{
+    protected function getFieldTypeIdentifier(): string
+    {
+        return 'novaseometas';
+    }
+
+    public function mapToFieldValueType(FieldDefinition $fieldDefinition): ?string
+    {
+        if (!$this->canMap($fieldDefinition)) {
+            return parent::mapToFieldValueType($fieldDefinition);
+        }
+
+        return "NovaSeoMetasFieldValue";
+    }
+
+    public function mapToFieldValueResolver(FieldDefinition $fieldDefinition): ?string
+    {
+        if (!$this->canMap($fieldDefinition)) {
+            return parent::mapToFieldValueResolver($fieldDefinition);
+        }
+
+        return '@=resolver("NovaSeoMetasFieldValue", [value, "' . $fieldDefinition->identifier . '"])';
+    }
+
+}

--- a/components/SEOBundle/bundle/GraphQL/Schema/Domain/MetaFieldsDomain.php
+++ b/components/SEOBundle/bundle/GraphQL/Schema/Domain/MetaFieldsDomain.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Novactive\Bundle\eZSEOBundle\GraphQL\Schema\Domain;
+
+use Generator;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use EzSystems\EzPlatformGraphQL\Schema;
+use EzSystems\EzPlatformGraphQL\Schema\Builder;
+use EzSystems\EzPlatformGraphQL\Schema\Domain;
+use Novactive\Bundle\eZSEOBundle\GraphQL\Helper\NameHelper;
+
+class MetaFieldsDomain implements Domain\Iterator, Schema\Worker
+{
+    const TYPE = 'NovaSeoMetasFieldValue';
+    const ARG = 'MetaField';
+
+    /**
+     * @var ConfigResolverInterface
+     */
+    private ConfigResolverInterface $configResolver;
+
+    private NameHelper $nameHelper;
+
+
+    public function __construct(ConfigResolverInterface $configResolver, NameHelper $nameHelper)
+    {
+        $this->configResolver = $configResolver;
+        $this->nameHelper = $nameHelper;
+    }
+
+    public function iterate(): Generator
+    {
+        $metasConfig = $this->configResolver->getParameter('fieldtype_metas', 'nova_ezseo');
+        foreach (array_keys($metasConfig) as $metaName) {
+            yield [self::ARG => $this->nameHelper->sanitizeMetaFieldName($metaName)];
+        }
+    }
+
+    public function init(Builder $schema)
+    {
+        $schema->addType(new Builder\Input\Type(
+            self::TYPE,
+            'object'
+        ));
+    }
+
+    public function work(Builder $schema, array $args)
+    {
+        $schema->addFieldToType(
+            self::TYPE,
+            new Builder\Input\Field($args[self::ARG], "String")
+        );
+    }
+
+    public function canWork(Builder $schema, array $args)
+    {
+        return array_key_exists(self::ARG, $args);
+    }
+
+    public function setNameHelper(NameHelper $nameHelper)
+    {
+        $this->nameHelper = $nameHelper;
+    }
+
+    protected function getNameHelper()
+    {
+        return $this->nameHelper;
+    }
+}

--- a/components/SEOBundle/bundle/Resources/config/graphql.yml
+++ b/components/SEOBundle/bundle/Resources/config/graphql.yml
@@ -1,0 +1,20 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter:
+        alias: 'serializer.name_converter.camel_case_to_snake_case'
+
+    Novactive\Bundle\eZSEOBundle\GraphQL\Helper\:
+        resource: '../../GraphQL/Helper'
+
+    Novactive\Bundle\eZSEOBundle\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\NovaeZSEOFieldDefinitionMapper:
+        decorates: EzSystems\EzPlatformGraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper
+
+    Novactive\Bundle\eZSEOBundle\GraphQL\Schema\Domain\MetaFieldsDomain:
+        tags:
+            - "ezplatform_graphql.schema_domain_iterator"
+            - "ezplatform_graphql.domain_schema_worker"
+
+    Novactive\Bundle\eZSEOBundle\GraphQL\Resolver\NovaEZSeoFieldResolver: ~

--- a/components/SEOBundle/bundle/Resources/config/services.yml
+++ b/components/SEOBundle/bundle/Resources/config/services.yml
@@ -50,6 +50,7 @@ services:
 
     Novactive\Bundle\eZSEOBundle\Twig\NovaeZSEOExtension: ~
     Novactive\Bundle\eZSEOBundle\Core\DummyCustomFallback: ~
+    Novactive\Bundle\eZSEOBundle\Service\MetaCompositionService: ~
 
     Novactive\Bundle\eZSEOBundle\Core\MetaNameSchema:
         lazy: true

--- a/components/SEOBundle/bundle/Service/MetaCompositionService.php
+++ b/components/SEOBundle/bundle/Service/MetaCompositionService.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Novactive\Bundle\eZSEOBundle\Service;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use Novactive\Bundle\eZSEOBundle\Core\CustomFallbackInterface;
+use Novactive\Bundle\eZSEOBundle\Core\FieldType\Metas\Value as MetasFieldValue;
+use Novactive\Bundle\eZSEOBundle\Core\Meta;
+use Novactive\Bundle\eZSEOBundle\Core\MetaNameSchema;
+
+class MetaCompositionService
+{
+    protected MetaNameSchema $metaNameSchema;
+
+    protected ConfigResolverInterface $configResolver;
+
+    protected Repository $eZRepository;
+
+    /**
+     * CustomFallBack Service.
+     *
+     * @var CustomFallbackInterface
+     */
+    protected ?CustomFallbackInterface $customFallBackService = null;
+
+    public function __construct(
+        Repository $repository,
+        MetaNameSchema $nameSchema,
+        ConfigResolverInterface $configResolver
+    ) {
+        $this->metaNameSchema = $nameSchema;
+        $this->eZRepository = $repository;
+        $this->configResolver = $configResolver;
+    }
+
+    public function setCustomFallbackService(CustomFallbackInterface $service)
+    {
+        $this->customFallBackService = $service;
+    }
+
+    /**
+     * @param ContentInfo $contentInfo
+     * @param string $metaName
+     * @return string
+     */
+    public function getFallbackedMetaContent(ContentInfo $contentInfo, string $metaName): string
+    {
+        if ($this->customFallBackService instanceof CustomFallbackInterface) {
+            return $this->customFallBackService->getMetaContent($metaName, $contentInfo);
+        }
+
+        return '';
+    }
+
+    /**
+     * @param Field $field
+     * @param $content
+     * @return array
+     * @throws InvalidArgumentType
+     */
+    public function computeMetasUsingFallback(Field $field, $content): array
+    {
+        $this->computeMetas($field, $content);
+        $metaFieldValues = $field->value;
+
+        return array_map(function(Meta $meta) use ($content) {
+            if ($meta->isEmpty())
+            {
+                $meta->setContent(
+                    $this->getFallbackedMetaContent(
+                        $content instanceof Content ? $content->contentInfo : $content,
+                        $meta->getName()
+                    )
+                );
+            }
+
+            return $meta;
+        }, $metaFieldValues->metas);
+    }
+
+    /**
+     * Compute Metas of the Field thanks to its Content and the Fallback.
+     */
+    // @param $content: use type Content rather than ContentInfo, the last one is @deprecated
+    public function computeMetas(Field $field, $content): void
+    {
+        $fallback = false;
+        $languages = $this->configResolver->getParameter('languages');
+
+        if ($content instanceof ContentInfo) {
+            try {
+                $content = $this->eZRepository->getContentService()->loadContentByContentInfo($content, $languages);
+            } catch (NotFoundException | UnauthorizedException $e) {
+                return;
+            }
+        } elseif (!($content instanceof Content)) {
+            throw new InvalidArgumentType('$content', 'Content of ContentType');
+        }
+
+        $contentMetas = $this->innerComputeMetas($content, $field, $fallback);
+
+        if ($fallback && !$this->customFallBackService) {
+            $rootContent = $this->eZRepository->getLocationService()->loadLocation(
+                $this->configResolver->getParameter('content.tree_root.location_id')
+            )->getContent();
+
+            // We need to load the good field too
+            $metasIdentifier = $this->configResolver->getParameter('fieldtype_metas_identifier', 'nova_ezseo');
+            $rootMetas = $this->innerComputeMetas($rootContent, $metasIdentifier, $fallback);
+
+            foreach ($contentMetas as $key => $metaContent) {
+                if (\array_key_exists($key, $rootMetas)) {
+                    $metaContent->setContent(
+                        $metaContent->isEmpty() ? $rootMetas[$key]->getContent() : $metaContent->getContent()
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Compute Meta by reference.
+     */
+    protected function innerComputeMetas(
+        Content $content,
+                $field,
+                &$needFallback = false
+    ): array {
+        if ($field instanceof Field) {
+            $metasFieldValue = $field->value;
+            $fieldDefIdentifier = $field->fieldDefIdentifier;
+        } else {
+            $metasFieldValue = $content->getFieldValue($field);
+            $fieldDefIdentifier = $field;
+        }
+
+        if ($metasFieldValue instanceof MetasFieldValue) {
+            $metasConfig = $this->configResolver->getParameter('fieldtype_metas', 'nova_ezseo');
+            // as the configuration is the last fallback we need to loop on it.
+            foreach (array_keys($metasConfig) as $metaName) {
+                if ($metasFieldValue->nameExists($metaName)) {
+                    $meta = $metasFieldValue->metas[$metaName];
+                } else {
+                    $meta = new Meta($metaName);
+                    $metasFieldValue->metas[$metaName] = $meta;
+                }
+
+                /** @var Meta $meta */
+                if ($meta->isEmpty()) {
+                    $meta->setContent($metasConfig[$meta->getName()]['default_pattern']);
+                    $fieldDefinition = $content->getContentType()->getFieldDefinition($fieldDefIdentifier);
+                    $configuration = $fieldDefinition->getFieldSettings()['configuration'];
+                    // but if we need something is the configuration we take it
+                    if (isset($configuration[$meta->getName()]) && !empty($configuration[$meta->getName()])) {
+                        $meta->setContent($configuration[$meta->getName()]);
+                    }
+                }
+                if (!$this->metaNameSchema->resolveMeta($meta, $content)) {
+                    $needFallback = true;
+                }
+            }
+
+            return $metasFieldValue->metas;
+        }
+
+        return [];
+    }
+}

--- a/components/SEOBundle/bundle/Twig/NovaeZSEOExtension.php
+++ b/components/SEOBundle/bundle/Twig/NovaeZSEOExtension.php
@@ -25,33 +25,14 @@ use Novactive\Bundle\eZSEOBundle\Core\CustomFallbackInterface;
 use Novactive\Bundle\eZSEOBundle\Core\FieldType\Metas\Value as MetasFieldValue;
 use Novactive\Bundle\eZSEOBundle\Core\Meta;
 use Novactive\Bundle\eZSEOBundle\Core\MetaNameSchema;
+use Novactive\Bundle\eZSEOBundle\Service\MetaCompositionService;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;
 use Twig\TwigFilter;
 
 class NovaeZSEOExtension extends AbstractExtension implements GlobalsInterface
 {
-    /**
-     * The eZ Publish object name pattern service (extended).
-     *
-     * @var MetaNameSchema
-     */
-    protected $metaNameSchema;
-
-    /**
-     * ConfigResolver useful to get the config aware of siteaccess.
-     *
-     * @var ConfigResolverInterface
-     */
-    protected $configResolver;
-
-    /**
-     * The eZ Publish API.
-     *
-     * @var Repository
-     */
-    protected $eZRepository;
-
+    protected MetaCompositionService $metaCompositionService;
     /**
      * Locale Converter.
      *
@@ -60,28 +41,22 @@ class NovaeZSEOExtension extends AbstractExtension implements GlobalsInterface
     protected $localeConverter;
 
     /**
-     * CustomFallBack Service.
-     *
-     * @var CustomFallbackInterface
+     * @var ConfigResolverInterface
      */
-    protected $customFallBackService;
+    protected $configResolver;
+
 
     public function __construct(
-        Repository $repository,
-        MetaNameSchema $nameSchema,
-        ConfigResolverInterface $configResolver,
-        LocaleConverter $localeConverter
+        MetaCompositionService $metaCompositionService,
+        LocaleConverter $localeConverter,
+        ConfigResolverInterface $configResolver
     ) {
-        $this->metaNameSchema = $nameSchema;
-        $this->eZRepository = $repository;
-        $this->configResolver = $configResolver;
+        $this->metaCompositionService = $metaCompositionService;
         $this->localeConverter = $localeConverter;
+        $this->configResolver = $configResolver;
     }
 
-    public function setCustomFallbackService(CustomFallbackInterface $service)
-    {
-        $this->customFallBackService = $service;
-    }
+
 
     public function getFilters()
     {
@@ -95,105 +70,6 @@ class NovaeZSEOExtension extends AbstractExtension implements GlobalsInterface
     public function getPosixLocale(string $eZLocale): ?string
     {
         return $this->localeConverter->convertToPOSIX($eZLocale);
-    }
-
-    public function getFallbackedMetaContent(ContentInfo $contentInfo, string $metaName): string
-    {
-        if ($this->customFallBackService instanceof CustomFallbackInterface) {
-            return $this->customFallBackService->getMetaContent($metaName, $contentInfo);
-        }
-
-        return '';
-    }
-
-    /**
-     * Compute Metas of the Field thanks to its Content and the Fallback.
-     */
-    // @param $content: use type Content rather than ContentInfo, the last one is @deprecated
-    public function computeMetas(Field $field, $content): string
-    {
-        $fallback = false;
-        $languages = $this->configResolver->getParameter('languages');
-
-        if ($content instanceof ContentInfo) {
-            try {
-                $content = $this->eZRepository->getContentService()->loadContentByContentInfo($content, $languages);
-            } catch (NotFoundException | UnauthorizedException $e) {
-                return '';
-            }
-        } elseif (!($content instanceof Content)) {
-            throw new InvalidArgumentType('$content', 'Content of ContentType');
-        }
-
-        $contentMetas = $this->innerComputeMetas($content, $field, $fallback);
-
-        if ($fallback && !$this->customFallBackService) {
-            $rootContent = $this->eZRepository->getLocationService()->loadLocation(
-                $this->configResolver->getParameter('content.tree_root.location_id')
-            )->getContent();
-
-            // We need to load the good field too
-            $metasIdentifier = $this->configResolver->getParameter('fieldtype_metas_identifier', 'nova_ezseo');
-            $rootMetas = $this->innerComputeMetas($rootContent, $metasIdentifier, $fallback);
-
-            foreach ($contentMetas as $key => $metaContent) {
-                if (\array_key_exists($key, $rootMetas)) {
-                    $metaContent->setContent(
-                        $metaContent->isEmpty() ? $rootMetas[$key]->getContent() : $metaContent->getContent()
-                    );
-                }
-            }
-        }
-
-        return '';
-    }
-
-    /**
-     * Compute Meta by reference.
-     */
-    protected function innerComputeMetas(
-        Content $content,
-        $field,
-        &$needFallback = false
-    ): array {
-        if ($field instanceof Field) {
-            $metasFieldValue = $field->value;
-            $fieldDefIdentifier = $field->fieldDefIdentifier;
-        } else {
-            $metasFieldValue = $content->getFieldValue($field);
-            $fieldDefIdentifier = $field;
-        }
-
-        if ($metasFieldValue instanceof MetasFieldValue) {
-            $metasConfig = $this->configResolver->getParameter('fieldtype_metas', 'nova_ezseo');
-            // as the configuration is the last fallback we need to loop on it.
-            foreach (array_keys($metasConfig) as $metaName) {
-                if ($metasFieldValue->nameExists($metaName)) {
-                    $meta = $metasFieldValue->metas[$metaName];
-                } else {
-                    $meta = new Meta($metaName);
-                    $metasFieldValue->metas[$metaName] = $meta;
-                }
-
-                /** @var Meta $meta */
-                if ($meta->isEmpty()) {
-                    $meta->setContent($metasConfig[$meta->getName()]['default_pattern']);
-                    $fieldDefinition = $content->getContentType()->getFieldDefinition($fieldDefIdentifier);
-                    $configuration = $fieldDefinition->getFieldSettings()['configuration'];
-                    // but if we need something is the configuration we take it
-                    if (isset($configuration[$meta->getName()]) && !empty($configuration[$meta->getName()])) {
-                        $meta->setContent($configuration[$meta->getName()]);
-                    }
-                }
-                if (!$this->metaNameSchema->resolveMeta($meta, $content)) {
-                    $needFallback = true;
-                }
-            }
-
-            return $metasFieldValue->metas;
-        }
-
-        return [];
     }
 
     public function getName()

--- a/components/SEOBundle/documentation/CHANGELOG.md
+++ b/components/SEOBundle/documentation/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add new `sitemap_includes` configuration to specifically 'include' instead of 'exclude'.
 * Ignore `sitemap_excludes` misconfiguration when necessary
 * Update the Makefile for better contributor install 
+* Integrate meta field type with ezplatform's graphql schema
 
 ## 5.0.0
 

--- a/components/SEOBundle/documentation/INSTALL.md
+++ b/components/SEOBundle/documentation/INSTALL.md
@@ -51,3 +51,8 @@ Add a `#` at the beginning of the line
 ```
 #RewriteRule ^/robots\.txt - [L]
 ```
+
+#### Regenerate graphql schema
+```
+php bin/console ezplatform:graphql:generate-schema
+```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | feat-seo-bundle-grapqhl-integration
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Fixed tickets | -

This adds integration of the meta information field type into ezplatform's/ibexa's graphql schema. The available fields are generated based on configuration when generating the schema with `bin/console ezplatform:graphql:generate-schema`
