### PR TITLE
[eZNovaMaintenanceBundle] Page 503 behind Varnish or Fastly #72

### DIFF
--- a/components/MaintenanceBundle/README.md
+++ b/components/MaintenanceBundle/README.md
@@ -48,6 +48,17 @@ _novaezmaintenance_routes:
 php app|ezpublish/console cache:clear --env=dev
 ```
 
+### Step 5: check X-Maintenance response header to VCL
+Maintenance page will return 503 status code and VCL will abandon it,
+So update your vcl to force displaying response with 503 and X-Maintenance header
+
+```vcl
+if (bereq.http.accept ~ "application/vnd.fos.user-context-hash"
+        && beresp.status >= 500 && !beresp.http.X-Maintenance
+    ) {
+        return (abandon);
+    }
+```
 
 ## Configuration
 

--- a/components/MaintenanceBundle/bundle/Helper/FileHelper.php
+++ b/components/MaintenanceBundle/bundle/Helper/FileHelper.php
@@ -135,6 +135,7 @@ class FileHelper
         if (null !== $status) {
             $response->setStatusCode($status);
         }
+        $response->headers->add(["X-Maintenance"=> 1]);
 
         return $response->setContent($content);
     }


### PR DESCRIPTION
- Add "X-Maintenance" to response headers
- Update your VCL to display response with 503 status code and "X-Maintenance" header

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Fixed tickets | [#97793 - Page de maintenance KO en prod](https://almaviacx.easyredmine.com/issues/97793)

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
