### PR TITLE
Fix error with ibexa:encore:compile

### DIFF
--- a/components/EnhancedImageAssetBundle/src/bundle/Resources/public/css/enhancedimage-field.scss
+++ b/components/EnhancedImageAssetBundle/src/bundle/Resources/public/css/enhancedimage-field.scss
@@ -19,7 +19,7 @@ $ibexa-border-radius: calculateRem(2px);
 $base-font-size: 16px;
 
 @function calculateRem($size) {
-    $remSize: $size / $base-font-size;
+    $remSize: calc(#{$size} / #{$base-font-size});
 
     @return #{$remSize}rem;
 }


### PR DESCRIPTION
RUN  Evaluating command yarn encore prod

yarn run v1.22.18
$ /app/ezplatform/node_modules/.bin/encore prod
Running webpack ...
ERR  DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
ERR  Recommendation: math.div($size, $base-font-size) or calc($size / $base-font-size)
ERR  More info and automated migrator: https://sass-lang.com/d/slash-div

22 │     $remSize: $size / $base-font-size;

vendor/novactive/ezenhancedimageassetbundle/src/bundle/Resources/public/css/enhancedimage-field.scss 22:15  calculateRem()
vendor/novactive/ezenhancedimageassetbundle/src/bundle/Resources/public/css/enhancedimage-field.scss 29:16  error-input()
vendor/novactive/ezenhancedimageassetbundle/src/bundle/Resources/public/css/enhancedimage-field.scss 51:5   error-under-label()
vendor/novactive/ezenhancedimageassetbundle/src/bundle/Resources/public/css/enhancedimage-field.scss 93:9   root stylesheet
