### PR TITLE
FIX Error: Cannot divide by "px", number expected  by "yarn encore prod"

### DIFF
--- a/components/EnhancedImageAssetBundle/src/bundle/Resources/public/css/enhancedimage-field.scss
+++ b/components/EnhancedImageAssetBundle/src/bundle/Resources/public/css/enhancedimage-field.scss
@@ -16,7 +16,7 @@ $ibexa-color-font: #131c26;
 
 $ibexa-border-radius: calculateRem(2px);
 
-$base-font-size: 16px;
+$base-font-size: 16;
 
 @function calculateRem($size) {
     $remSize: calc(#{$size} / #{$base-font-size});


### PR DESCRIPTION
FIX generated error by "yarn encore prod" cmd in ibexa/commerce v3.3.22 and nodejs v14.0.0 postcss "^7.0.0" postcss-calc "^7.0.1"

yarn run v1.22.4
$ /var/www/html/project/ezplatform/node_modules/.bin/encore prod
Running webpack ...

I 1185 files written to public/assets/build
Error: Cannot divide by "px", number expected
at /var/www/html/project/ezplatform/ezplatform-admin-ui-content-edit-parts-css.4f0325aa.css:804:3

| Q             | A
| ------------- | ---
| Branch?       | master / x.y.z
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- don't forget updating documentation/CHANGELOG.md files -->
| BC breaks?    | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
