### PR TITLE
Fix - apply the default image quality parameters

### DIFF
--- a/components/EnhancedImageAssetBundle/src/lib/Imagine/Filter/FilterConfiguration.php
+++ b/components/EnhancedImageAssetBundle/src/lib/Imagine/Filter/FilterConfiguration.php
@@ -46,7 +46,7 @@ class FilterConfiguration extends BaseFilterConfiguration
     public function get($filter): array
     {
         $defaultPostProcessors = $this->getDefaultPostProcessors();
-        $defaultConfig = $this->getDefaultConfig();
+        $defaultConfig = (array) $this->getDefaultConfig();
         $config = $this->filterConfiguration->get($filter);
 
         $config = array_merge(
@@ -56,7 +56,7 @@ class FilterConfiguration extends BaseFilterConfiguration
                 'webp_quality' => 70,
                 'png_compression_level' => 6,
             ],
-            $config
+            $defaultConfig, $config
         );
 
         if ($defaultPostProcessors && (!isset($config['post_processors']) || empty($config['post_processors']))) {


### PR DESCRIPTION
apply the image quality parameters of `ez_enhanced_image_asset.default.image_default_config  ` if the image quality parameters is not set in ` liip_imagine.default_filter_set_settings`

| Q             | A
| ------------- | ---
| Branch?       | master / x.y.z
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- don't forget updating documentation/CHANGELOG.md files -->
| BC breaks?    | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
