### PR TITLE
use Ibexa

### DIFF
--- a/components/MenuManagerBundle/src/bundle/Controller/AdminController.php
+++ b/components/MenuManagerBundle/src/bundle/Controller/AdminController.php
@@ -25,7 +25,9 @@ use Pagerfanta\Adapter\DoctrineORMAdapter;
 use Pagerfanta\Pagerfanta;
 use PDO;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -39,17 +41,10 @@ class AdminController extends Controller
 {
     public const RESULTS_PER_PAGE = 20;
 
-    /** @var TranslatorInterface */
-    protected $translator;
-
-    /** @var NotificationHandlerInterface */
-    protected $notificationHandler;
-
-    /** @var EntityManagerInterface */
-    protected $em;
-
-    /** @var ConfigResolverInterface */
-    protected $configResolver;
+    protected TranslatorInterface $translator;
+    protected NotificationHandlerInterface $notificationHandler;
+    protected EntityManagerInterface $em;
+    protected ConfigResolverInterface $configResolver;
 
     /**
      * AdminController constructor.
@@ -73,7 +68,7 @@ class AdminController extends Controller
      *
      * @SuppressWarnings(PHPMD.IfStatementAssignment)
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function listAction(Request $request, $page = 1)
     {
@@ -143,7 +138,7 @@ class AdminController extends Controller
     /**
      * @Route("/new", name="menu_manager.menu_new")
      *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     * @return RedirectResponse|Response
      */
     public function newAction(Request $request)
     {
@@ -158,10 +153,13 @@ class AdminController extends Controller
     /**
      * @Route("/edit/{menu}", name="menu_manager.menu_edit")
      *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     * @param Request $request
+     * @param Menu $menu
+     * @return RedirectResponse|Response
      */
-    public function editAction(Request $request, Menu $menu)
+    public function editAction(Request $request, Menu $menu): RedirectResponse|Response
     {
+        // dump($menu); // Ici on a bien un Novactive\EzMenuManagerBundle\Entity\Menu
         $form = $this->createForm(MenuType::class, $menu);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {

--- a/components/MenuManagerBundle/src/bundle/Controller/AdminController.php
+++ b/components/MenuManagerBundle/src/bundle/Controller/AdminController.php
@@ -157,7 +157,7 @@ class AdminController extends Controller
      * @param Menu $menu
      * @return RedirectResponse|Response
      */
-    public function editAction(Request $request, Menu $menu): RedirectResponse|Response
+    public function editAction(Request $request, Menu $menu)
     {
         $form = $this->createForm(MenuType::class, $menu);
         $form->handleRequest($request);

--- a/components/MenuManagerBundle/src/bundle/Controller/AdminController.php
+++ b/components/MenuManagerBundle/src/bundle/Controller/AdminController.php
@@ -159,7 +159,6 @@ class AdminController extends Controller
      */
     public function editAction(Request $request, Menu $menu): RedirectResponse|Response
     {
-        // dump($menu); // Ici on a bien un Novactive\EzMenuManagerBundle\Entity\Menu
         $form = $this->createForm(MenuType::class, $menu);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {

--- a/components/MenuManagerBundle/src/bundle/Controller/ViewController.php
+++ b/components/MenuManagerBundle/src/bundle/Controller/ViewController.php
@@ -12,9 +12,10 @@
 
 namespace Novactive\EzMenuManagerBundle\Controller;
 
-use EzSystems\EzPlatformAdminUiBundle\Controller\Controller;
+use Ibexa\Contracts\AdminUi\Controller\Controller;
 use Novactive\EzMenuManager\Service\MenuBuilder;
 use Novactive\EzMenuManagerBundle\Entity\Menu;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -29,7 +30,7 @@ class ViewController extends Controller
     /**
      * @Route("/view/{menu}", name="menu_manager.menu_view")
      */
-    public function viewMenuAction(Menu $menu, MenuBuilder $menuBuilder)
+    public function viewMenuAction(Menu $menu, MenuBuilder $menuBuilder): Response
     {
         return $this->render(
             '@ibexadesign/menu_manager/view.html.twig',

--- a/components/MenuManagerBundle/src/bundle/Entity/MenuItem.php
+++ b/components/MenuManagerBundle/src/bundle/Entity/MenuItem.php
@@ -296,7 +296,7 @@ class MenuItem
         return (string) $this->id;
     }
 
-    public function update(array $properties)
+    public function update(array $properties): void
     {
         foreach ($properties as $property => $value) {
             $this->$property = $value;

--- a/components/MenuManagerBundle/src/bundle/Entity/MenuItem/ContentMenuItem.php
+++ b/components/MenuManagerBundle/src/bundle/Entity/MenuItem/ContentMenuItem.php
@@ -36,7 +36,7 @@ class ContentMenuItem extends MenuItem
     /**
      * @param int $contentId
      */
-    public function setContentId($contentId): void
+    public function setContentId(int $contentId): void
     {
         if (!$contentId) {
             $this->setUrl(null);

--- a/components/MenuManagerBundle/src/lib/EventListener/MenuListener.php
+++ b/components/MenuManagerBundle/src/lib/EventListener/MenuListener.php
@@ -12,20 +12,20 @@
 
 namespace Novactive\EzMenuManager\EventListener;
 
-use EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent;
-use EzSystems\EzPlatformAdminUi\Menu\MainMenuBuilder;
+use Ibexa\AdminUi\Menu\Event\ConfigureMenuEvent;
+use Ibexa\AdminUi\Menu\MainMenuBuilder;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class MenuListener implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ConfigureMenuEvent::MAIN_MENU => ['onMenuConfigure', 0],
         ];
     }
 
-    public function onMenuConfigure(ConfigureMenuEvent $event)
+    public function onMenuConfigure(ConfigureMenuEvent $event): void
     {
         $menu = $event->getMenu();
 

--- a/components/MenuManagerBundle/src/lib/FieldType/Mapper/MenuItemFormMapper.php
+++ b/components/MenuManagerBundle/src/lib/FieldType/Mapper/MenuItemFormMapper.php
@@ -12,10 +12,10 @@
 
 namespace Novactive\EzMenuManager\FieldType\Mapper;
 
-use EzSystems\EzPlatformAdminUi\FieldType\FieldDefinitionFormMapperInterface;
-use EzSystems\EzPlatformAdminUi\Form\Data\FieldDefinitionData;
-use EzSystems\EzPlatformContentForms\Data\Content\FieldData;
-use EzSystems\EzPlatformContentForms\FieldType\FieldValueFormMapperInterface;
+use Ibexa\AdminUi\FieldType\FieldDefinitionFormMapperInterface;
+use Ibexa\AdminUi\Form\Data\FieldDefinitionData;
+use Ibexa\Contracts\ContentForms\Data\Content\FieldData;
+use Ibexa\Contracts\ContentForms\FieldType\FieldValueFormMapperInterface;
 use Novactive\EzMenuManager\Form\Type\FieldType\MenuItemFieldType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -26,7 +26,7 @@ class MenuItemFormMapper implements FieldDefinitionFormMapperInterface, FieldVal
     {
     }
 
-    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data)
+    public function mapFieldValueForm(FormInterface $fieldForm, FieldData $data): void
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();
@@ -50,7 +50,7 @@ class MenuItemFormMapper implements FieldDefinitionFormMapperInterface, FieldVal
             );
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults(

--- a/components/MenuManagerBundle/src/lib/FieldType/MenuItem/MenuItemStorage/Gateway.php
+++ b/components/MenuManagerBundle/src/lib/FieldType/MenuItem/MenuItemStorage/Gateway.php
@@ -12,9 +12,9 @@
 
 namespace Novactive\EzMenuManager\FieldType\MenuItem\MenuItemStorage;
 
-use eZ\Publish\SPI\FieldType\StorageGateway;
-use eZ\Publish\SPI\Persistence\Content\Field;
-use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+use Ibexa\Contracts\Core\FieldType\StorageGateway;
+use Ibexa\Contracts\Core\Persistence\Content\Field;
+use Ibexa\Contracts\Core\Persistence\Content\VersionInfo;
 
 abstract class Gateway extends StorageGateway
 {

--- a/components/MenuManagerBundle/src/lib/FieldType/MenuItem/MenuItemStorage/Gateway/DoctrineStorage.php
+++ b/components/MenuManagerBundle/src/lib/FieldType/MenuItem/MenuItemStorage/Gateway/DoctrineStorage.php
@@ -13,8 +13,8 @@
 namespace Novactive\EzMenuManager\FieldType\MenuItem\MenuItemStorage\Gateway;
 
 use Doctrine\ORM\EntityManagerInterface;
-use eZ\Publish\SPI\Persistence\Content\Field;
-use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+use Ibexa\Contracts\Core\Persistence\Content\Field;
+use Ibexa\Contracts\Core\Persistence\Content\VersionInfo;
 use Novactive\EzMenuManager\FieldType\MenuItem\MenuItemStorage\Gateway;
 use Novactive\EzMenuManager\FieldType\MenuItem\Value;
 use Novactive\EzMenuManager\FieldType\MenuItem\ValueConverter;
@@ -23,11 +23,9 @@ use Novactive\EzMenuManagerBundle\Entity\MenuItem\ContentMenuItem;
 
 class DoctrineStorage extends Gateway
 {
-    /** @var EntityManagerInterface */
-    protected $em;
+    protected EntityManagerInterface $em;
 
-    /** @var ValueConverter */
-    protected $valueConverter;
+    protected ValueConverter $valueConverter;
 
     /**
      * DoctrineStorage constructor.
@@ -42,7 +40,7 @@ class DoctrineStorage extends Gateway
     {
     }
 
-    public function getFieldData(VersionInfo $versionInfo, Field $field)
+    public function getFieldData(VersionInfo $versionInfo, Field $field): void
     {
         $menuItems = $this->em->getRepository(MenuItem::class)->findBy(
             [
@@ -53,7 +51,7 @@ class DoctrineStorage extends Gateway
         $field->value->externalData = $this->valueConverter->toHash(new Value($menuItems));
     }
 
-    public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds)
+    public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds): void
     {
         /** @var ContentMenuItem[] $menuItems */
         $menuItems = $this->em->getRepository(MenuItem::class)->findBy(

--- a/components/MenuManagerBundle/src/lib/FieldType/MenuItem/SearchField.php
+++ b/components/MenuManagerBundle/src/lib/FieldType/MenuItem/SearchField.php
@@ -12,7 +12,6 @@
 
 namespace Novactive\EzMenuManager\FieldType\MenuItem;
 
-use eZ\Publish\SPI\Search;
 use Ibexa\Contracts\Core\FieldType\Indexable;
 use Ibexa\Contracts\Core\Persistence\Content\Field;
 use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition;
@@ -24,7 +23,7 @@ class SearchField implements Indexable
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData(Field $field, FieldDefinition $fieldDefinition)
+    public function getIndexData(Field $field, FieldDefinition $fieldDefinition): array
     {
         return [];
     }
@@ -34,7 +33,7 @@ class SearchField implements Indexable
      *
      * @return \eZ\Publish\SPI\Search\FieldType[]
      */
-    public function getIndexDefinition()
+    public function getIndexDefinition(): array
     {
         return [];
     }
@@ -46,9 +45,9 @@ class SearchField implements Indexable
      * implementation of this interface), this method is used to define default
      * field for matching. Default field is typically used by Field criterion.
      *
-     * @return string
+     * @return string|null
      */
-    public function getDefaultMatchField()
+    public function getDefaultMatchField(): ?string
     {
         return null;
     }
@@ -60,9 +59,9 @@ class SearchField implements Indexable
      * implementation of this interface), this method is used to define default
      * field for sorting. Default field is typically used by Field sort clause.
      *
-     * @return string
+     * @return string|null
      */
-    public function getDefaultSortField()
+    public function getDefaultSortField(): ?string
     {
         return null;
     }

--- a/components/MenuManagerBundle/src/lib/FieldType/MenuItem/Value.php
+++ b/components/MenuManagerBundle/src/lib/FieldType/MenuItem/Value.php
@@ -36,10 +36,15 @@ class Value extends BaseValue
     }
 
     /**
-     * @see \eZ\Publish\Core\FieldType\Value
+     * @see \Ibexa\Core\FieldType\Value
+     * @see MenuItem
      */
     public function __toString()
     {
-        return (string) $this->menuItems; // TODO Array to string conversion
+        $string = '';
+        foreach ($this->menuItems as $menuItem) {
+            $string .= ', ' . $menuItem->__toString();
+        }
+        return $string;
     }
 }

--- a/components/MenuManagerBundle/src/lib/FieldType/MenuItem/Value.php
+++ b/components/MenuManagerBundle/src/lib/FieldType/MenuItem/Value.php
@@ -22,16 +22,17 @@ class Value extends BaseValue
      *
      * @var MenuItem\ContentMenuItem[]
      */
-    public $menuItems;
+    public array $menuItems;
 
     /**
      * Construct a new Value object and initialize it $text.
      *
      * @param array $menuItems
      */
-    public function __construct($menuItems = [])
+    public function __construct(array $menuItems = [])
     {
         $this->menuItems = $menuItems;
+        parent::__construct();
     }
 
     /**
@@ -39,6 +40,6 @@ class Value extends BaseValue
      */
     public function __toString()
     {
-        return (string) $this->menuItems;
+        return (string) $this->menuItems; // TODO Array to string conversion
     }
 }

--- a/components/MenuManagerBundle/src/lib/Form/Type/MenuType.php
+++ b/components/MenuManagerBundle/src/lib/Form/Type/MenuType.php
@@ -24,8 +24,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class MenuType extends AbstractType
 {
-    /** @var ConfigResolverInterface */
-    protected $configResolver;
+    protected ConfigResolverInterface $configResolver;
 
     /**
      * @required
@@ -35,7 +34,7 @@ class MenuType extends AbstractType
         $this->configResolver = $configResolver;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults(
@@ -45,7 +44,7 @@ class MenuType extends AbstractType
             );
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $menuTypes = $this->configResolver->getParameter('menu_types', 'nova_menu_manager') ?? [];
         $builder

--- a/components/MenuManagerBundle/src/lib/MenuItem/MenuItemConverter.php
+++ b/components/MenuManagerBundle/src/lib/MenuItem/MenuItemConverter.php
@@ -12,22 +12,22 @@
 
 namespace Novactive\EzMenuManager\MenuItem;
 
+use Novactive\EzMenuManager\Exception\MenuItemTypeNotFoundException;
 use Novactive\EzMenuManager\Exception\UnexpectedTypeException;
 use Novactive\EzMenuManagerBundle\Entity\MenuItem;
 
 class MenuItemConverter
 {
-    /** @var MenuItemTypeRegistry */
-    protected $menuItemTypeRegistry;
+    protected MenuItemTypeRegistry $menuItemTypeRegistry;
 
-    /**
-     * MenuItemConverter constructor.
-     */
     public function __construct(MenuItemTypeRegistry $menuItemTypeRegistry)
     {
         $this->menuItemTypeRegistry = $menuItemTypeRegistry;
     }
 
+    /**
+     * @throws MenuItemTypeNotFoundException
+     */
     public function toHash(MenuItem $menuItem): array
     {
         $type = $this->menuItemTypeRegistry->getMenuItemEntityType($menuItem);
@@ -37,10 +37,11 @@ class MenuItemConverter
 
     /**
      * @param $hash
-     *
-     * @return MenuItem
+     * @param string $defaultClass
+     * @return MenuItem|null
+     * @throws MenuItemTypeNotFoundException
      */
-    public function fromHash($hash, $defaultClass = MenuItem::class): ?MenuItem
+    public function fromHash($hash, string $defaultClass = MenuItem::class): ?MenuItem
     {
         $type = $this->menuItemTypeRegistry->getMenuItemType($defaultClass);
 
@@ -50,6 +51,7 @@ class MenuItemConverter
     /**
      * @param $menuItems
      *
+     * @return array
      * @throws UnexpectedTypeException
      */
     public function toHashArray($menuItems): array
@@ -66,23 +68,25 @@ class MenuItemConverter
     }
 
     /**
+     * @param array $hashArray
      * @param string $defaultClass
      *
+     * @return MenuItem[]
      * @SuppressWarnings(PHPMD.IfStatementAssignment)
      *
-     * @return MenuItem[]
+     * @throws MenuItemTypeNotFoundException
      */
-    public function fromHashArray(array $hashArray, $defaultClass = MenuItem::class): array
+    public function fromHashArray(array $hashArray, string $defaultClass = MenuItem::class): array
     {
         /** @var MenuItem[] $menuItems */
         $menuItems = [];
         foreach ($hashArray as $hashItem) {
-            $menuItem = $this->fromHash($hashItem, isset($hashItem['type']) ? $hashItem['type'] : $defaultClass);
+            $menuItem = $this->fromHash($hashItem, $hashItem['type'] ?? $defaultClass);
             if ($menuItem) {
                 $menuItems[$hashItem['id']] = $menuItem;
                 if (
                     !$menuItem->getParent()
-                    && 0 === strpos($hashItem['parentId'], '_')
+                    && str_starts_with($hashItem['parentId'], '_')
                     && ($parent = $menuItems[$hashItem['parentId']] ?? null)
                 ) {
                     $parent->addChildren($menuItem);

--- a/components/MenuManagerBundle/src/lib/MenuItem/MenuItemConverter.php
+++ b/components/MenuManagerBundle/src/lib/MenuItem/MenuItemConverter.php
@@ -86,7 +86,7 @@ class MenuItemConverter
                 $menuItems[$hashItem['id']] = $menuItem;
                 if (
                     !$menuItem->getParent()
-                    && str_starts_with($hashItem['parentId'], '_')
+                    && 0 === strpos($hashItem['parentId'], '_')
                     && ($parent = $menuItems[$hashItem['parentId']] ?? null)
                 ) {
                     $parent->addChildren($menuItem);

--- a/components/MenuManagerBundle/src/lib/MenuItem/Type/ContentMenuItemType.php
+++ b/components/MenuManagerBundle/src/lib/MenuItem/Type/ContentMenuItemType.php
@@ -23,9 +23,11 @@ use Novactive\EzMenuManager\MenuItem\MenuItemValue;
 use Novactive\EzMenuManagerBundle\Entity\MenuItem;
 use Psr\Cache\CacheException;
 use Psr\Cache\InvalidArgumentException;
+use RuntimeException;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Throwable;
 
 class ContentMenuItemType extends DefaultMenuItemType
 {
@@ -142,7 +144,7 @@ class ContentMenuItemType extends DefaultMenuItemType
             $link->setExtras($menuItemLinkInfos['extras']);
 
             return $link;
-        } catch (UnauthorizedException|\Throwable $e) {
+        } catch (UnauthorizedException|Throwable $e) {
             return null;
         }
     }
@@ -160,7 +162,7 @@ class ContentMenuItemType extends DefaultMenuItemType
         }
 
         if (!$menuItem instanceof MenuItem\ContentMenuItem) {
-            throw new \RuntimeException();
+            throw new RuntimeException(sprintf("%s only works with ContentMenuItem", __METHOD__));
         }
         $content = $this->contentService->loadContent($menuItem->getContentId());
         $location = $this->locationService->loadLocation($content->contentInfo->mainLocationId);

--- a/components/MenuManagerBundle/src/lib/Persistence/Legacy/Content/FieldValue/Converter/MenuItemConverter.php
+++ b/components/MenuManagerBundle/src/lib/Persistence/Legacy/Content/FieldValue/Converter/MenuItemConverter.php
@@ -12,11 +12,11 @@
 
 namespace Novactive\EzMenuManager\Persistence\Legacy\Content\FieldValue\Converter;
 
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
-use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
-use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
-use eZ\Publish\SPI\Persistence\Content\FieldValue;
-use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use Ibexa\Contracts\Core\Persistence\Content\FieldValue;
+use Ibexa\Contracts\Core\Persistence\Content\Type\FieldDefinition;
+use Ibexa\Core\Persistence\Legacy\Content\FieldValue\Converter;
+use Ibexa\Core\Persistence\Legacy\Content\StorageFieldDefinition;
+use Ibexa\Core\Persistence\Legacy\Content\StorageFieldValue;
 
 class MenuItemConverter implements Converter
 {
@@ -25,11 +25,11 @@ class MenuItemConverter implements Converter
      *
      * Note: Class should instead be configured as service if it gains dependencies.
      *
+     * @return MenuItemConverter
      * @deprecated since 6.8, will be removed in 7.x, use default constructor instead.
      *
-     * @return \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLineConverter
      */
-    public static function create()
+    public static function create(): MenuItemConverter
     {
         return new self();
     }
@@ -37,7 +37,7 @@ class MenuItemConverter implements Converter
     /**
      * Converts data from $value to $storageFieldValue.
      */
-    public function toStorageValue(FieldValue $value, StorageFieldValue $storageFieldValue)
+    public function toStorageValue(FieldValue $value, StorageFieldValue $storageFieldValue): void
     {
         $storageFieldValue->dataText = json_encode(
             is_array($value->externalData) && !empty($value->externalData) ?
@@ -49,9 +49,9 @@ class MenuItemConverter implements Converter
     /**
      * Converts data from $storageFieldValue to $value.
      */
-    public function toFieldValue(StorageFieldValue $storageFieldValue, FieldValue $value)
+    public function toFieldValue(StorageFieldValue $value, FieldValue $fieldValue): void
     {
-        $value->data = json_decode($storageFieldValue->dataText, true);
+        $fieldValue->data = json_decode($value->dataText, true);
     }
 
     /**
@@ -64,7 +64,7 @@ class MenuItemConverter implements Converter
     /**
      * Converts field definition data in $storageDef into $fieldDef.
      */
-    public function toFieldDefinition(StorageFieldDefinition $storageDef, FieldDefinition $fieldDef)
+    public function toFieldDefinition(StorageFieldDefinition $storageDef, FieldDefinition $fieldDef): void
     {
         $validatorConstraints = [];
 
@@ -80,7 +80,7 @@ class MenuItemConverter implements Converter
      *
      * @return string
      */
-    public function getIndexColumn()
+    public function getIndexColumn(): string
     {
         return 'sort_key_string';
     }

--- a/components/MenuManagerBundle/src/lib/Service/DataTransformer/MenuItemsCollectionTransformer.php
+++ b/components/MenuManagerBundle/src/lib/Service/DataTransformer/MenuItemsCollectionTransformer.php
@@ -12,8 +12,10 @@
 
 namespace Novactive\EzMenuManager\Service\DataTransformer;
 
+use Novactive\EzMenuManager\Exception\MenuItemTypeNotFoundException;
 use Novactive\EzMenuManager\Exception\UnexpectedTypeException;
 use Novactive\EzMenuManager\MenuItem\MenuItemConverter;
+use Novactive\EzMenuManagerBundle\Entity\MenuItem;
 use Symfony\Component\Form\DataTransformerInterface;
 
 class MenuItemsCollectionTransformer implements DataTransformerInterface
@@ -37,8 +39,6 @@ class MenuItemsCollectionTransformer implements DataTransformerInterface
      */
     public function transform($value): bool|string
     {
-        dump($value); // ici on a un Doctrine\ORM\PersistentCollection
-        dump($value->getValues()); // ERROR 500 TypeError ReflectionProperty::getValue(): Argument #1 ($object) must be provided for instance properties
         return json_encode($this->menuItemConverter->toHashArray($value->getValues()));
     }
 
@@ -46,9 +46,10 @@ class MenuItemsCollectionTransformer implements DataTransformerInterface
      * Transforms a hash into a FieldType Value using `FieldType::fromHash()`.
      * The FieldValue is compatible with `transform()`.
      *
-     * @return \eZ\Publish\SPI\FieldType\Value
+     * @return MenuItem[]
+     * @throws MenuItemTypeNotFoundException
      */
-    public function reverseTransform($value): \eZ\Publish\SPI\FieldType\Value
+    public function reverseTransform($value): array
     {
         return $this->menuItemConverter->fromHashArray(json_decode($value, true));
     }

--- a/components/MenuManagerBundle/src/lib/Service/DataTransformer/MenuItemsCollectionTransformer.php
+++ b/components/MenuManagerBundle/src/lib/Service/DataTransformer/MenuItemsCollectionTransformer.php
@@ -12,13 +12,13 @@
 
 namespace Novactive\EzMenuManager\Service\DataTransformer;
 
+use Novactive\EzMenuManager\Exception\UnexpectedTypeException;
 use Novactive\EzMenuManager\MenuItem\MenuItemConverter;
 use Symfony\Component\Form\DataTransformerInterface;
 
 class MenuItemsCollectionTransformer implements DataTransformerInterface
 {
-    /** @var MenuItemConverter */
-    protected $menuItemConverter;
+    protected MenuItemConverter $menuItemConverter;
 
     /**
      * MenuItemsCollection constructor.
@@ -32,10 +32,13 @@ class MenuItemsCollectionTransformer implements DataTransformerInterface
      * Transforms a FieldType Value into a hash using `FieldTpe::toHash()`.
      * This hash is compatible with `reverseTransform()`.
      *
-     * @return array|null the value's hash, or null if $value was not a FieldType Value
+     * @return string|false the value's hash, or null if $value was not a FieldType Value
+     * @throws UnexpectedTypeException
      */
-    public function transform($value)
+    public function transform($value): bool|string
     {
+        dump($value); // ici on a un Doctrine\ORM\PersistentCollection
+        dump($value->getValues()); // ERROR 500 TypeError ReflectionProperty::getValue(): Argument #1 ($object) must be provided for instance properties
         return json_encode($this->menuItemConverter->toHashArray($value->getValues()));
     }
 
@@ -45,7 +48,7 @@ class MenuItemsCollectionTransformer implements DataTransformerInterface
      *
      * @return \eZ\Publish\SPI\FieldType\Value
      */
-    public function reverseTransform($value)
+    public function reverseTransform($value): \eZ\Publish\SPI\FieldType\Value
     {
         return $this->menuItemConverter->fromHashArray(json_decode($value, true));
     }

--- a/components/MenuManagerBundle/src/lib/Service/DataTransformer/MenuItemsCollectionTransformer.php
+++ b/components/MenuManagerBundle/src/lib/Service/DataTransformer/MenuItemsCollectionTransformer.php
@@ -37,7 +37,7 @@ class MenuItemsCollectionTransformer implements DataTransformerInterface
      * @return string|false the value's hash, or null if $value was not a FieldType Value
      * @throws UnexpectedTypeException
      */
-    public function transform($value): bool|string
+    public function transform($value)
     {
         return json_encode($this->menuItemConverter->toHashArray($value->getValues()));
     }

--- a/components/StaticTemplatesBundle/bundle/Routing/Router.php
+++ b/components/StaticTemplatesBundle/bundle/Routing/Router.php
@@ -29,10 +29,25 @@ use Twig\Environment;
 
 class Router implements ChainedRouterInterface, RequestMatcherInterface, SiteAccessAware
 {
-    protected array $siteAccessGroups;
-    protected SiteAccess $siteAccess;
-    protected RequestContext $context;
-    protected Environment $twig;
+    /**
+     * @var array
+     */
+    protected $siteAccessGroups;
+
+    /**
+     * @var SiteAccess
+     */
+    protected $siteAccess;
+
+    /**
+     * @var RequestContext
+     */
+    protected $context;
+
+    /**
+     * @var Environment
+     */
+    protected $twig;
 
     public function __construct(array $siteAccessGroups, Environment $twig)
     {
@@ -84,9 +99,9 @@ class Router implements ChainedRouterInterface, RequestMatcherInterface, SiteAcc
         return new RouteCollection();
     }
 
-    public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH): string
+    public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH)
     {
-        return '';
+        // nothing to do
     }
 
     public function match($pathinfo)

--- a/components/StaticTemplatesBundle/bundle/Routing/Router.php
+++ b/components/StaticTemplatesBundle/bundle/Routing/Router.php
@@ -86,7 +86,6 @@ class Router implements ChainedRouterInterface, RequestMatcherInterface, SiteAcc
 
     public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH): string
     {
-        // Alors là ça m'étonnerait qu'on ne retourne rien !
         return '';
     }
 

--- a/components/StaticTemplatesBundle/bundle/Routing/Router.php
+++ b/components/StaticTemplatesBundle/bundle/Routing/Router.php
@@ -29,25 +29,10 @@ use Twig\Environment;
 
 class Router implements ChainedRouterInterface, RequestMatcherInterface, SiteAccessAware
 {
-    /**
-     * @var array
-     */
-    protected $siteAccessGroups;
-
-    /**
-     * @var SiteAccess
-     */
-    protected $siteAccess;
-
-    /**
-     * @var RequestContext
-     */
-    protected $context;
-
-    /**
-     * @var Environment
-     */
-    protected $twig;
+    protected array $siteAccessGroups;
+    protected SiteAccess $siteAccess;
+    protected RequestContext $context;
+    protected Environment $twig;
 
     public function __construct(array $siteAccessGroups, Environment $twig)
     {
@@ -99,9 +84,10 @@ class Router implements ChainedRouterInterface, RequestMatcherInterface, SiteAcc
         return new RouteCollection();
     }
 
-    public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH)
+    public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH): string
     {
-        // nothing to do
+        // Alors là ça m'étonnerait qu'on ne retourne rien !
+        return '';
     }
 
     public function match($pathinfo)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | feat-menumanager-ibx4-use-Ibexa => feat-menumanager-ibx4
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating documentation/CHANGELOG.md files -->
| BC breaks?    | no
| Fixed tickets | [#114982 - [LEF-Recette] Corriger l'édition du menu : ezmenumanagerbundle](https://almaviacx.easyredmine.com/issues/114982)

replace `use ez` by `use Ibexa` 

!! Symfony Exception **TypeError** HTTP 500 Internal Server Error

ReflectionProperty::getValue(): Argument #1 ($object) must be provided for instance properties