### PR TITLE
Fix round(): Argument #1 ($num) must be of type int|float, string given

### DIFF
--- a/components/EnhancedImageAssetBundle/src/lib/Imagine/ChainPlaceholderProvider.php
+++ b/components/EnhancedImageAssetBundle/src/lib/Imagine/ChainPlaceholderProvider.php
@@ -48,14 +48,6 @@ class ChainPlaceholderProvider implements PlaceholderProvider
         foreach ($providersConfigs as $providersConfig) {
             $provider = $this->providerRegistry->getProvider($providersConfig['provider']);
             try {
-                // In /var/www/html/ibexa/vendor/imagine/imagine/src/Image/Box.php:42
-                // round(): Argument #1 ($num) must be of type int|float, string given
-                if ($value->width === '') {
-                    $value->width = 0;
-                }
-                if ($value->height === '') {
-                    $value->height = 0;
-                }
                 return $provider->getPlaceholder($value, $providersConfig['options']);
             } catch (RuntimeException $exception) {
                 $this->logger->warning($exception->getMessage());

--- a/components/EnhancedImageAssetBundle/src/lib/Imagine/ChainPlaceholderProvider.php
+++ b/components/EnhancedImageAssetBundle/src/lib/Imagine/ChainPlaceholderProvider.php
@@ -48,6 +48,14 @@ class ChainPlaceholderProvider implements PlaceholderProvider
         foreach ($providersConfigs as $providersConfig) {
             $provider = $this->providerRegistry->getProvider($providersConfig['provider']);
             try {
+                // In /var/www/html/ibexa/vendor/imagine/imagine/src/Image/Box.php:42
+                // round(): Argument #1 ($num) must be of type int|float, string given
+                if ($value->width === '') {
+                    $value->width = 0;
+                }
+                if ($value->height === '') {
+                    $value->height = 0;
+                }
                 return $provider->getPlaceholder($value, $providersConfig['options']);
             } catch (RuntimeException $exception) {
                 $this->logger->warning($exception->getMessage());

--- a/components/EnhancedImageAssetBundle/src/lib/Imagine/Filter/Loader/PlaceholderFilterLoader.php
+++ b/components/EnhancedImageAssetBundle/src/lib/Imagine/Filter/Loader/PlaceholderFilterLoader.php
@@ -32,10 +32,16 @@ class PlaceholderFilterLoader implements LoaderInterface
         $origWidth = $size->getWidth();
         $origHeight = $size->getHeight();
 
-        if (null === $width || null === $height) {
-            if (null === $height) {
+        if (! $width || ! $height) {
+            // In /var/www/html/ibexa/vendor/imagine/imagine/src/Image/Box.php:42
+            // [TypeError]
+            // round(): Argument #1 ($num) must be of type int|float, string given
+            if (!$height && !$width) {
+                $height = $origWidth;
+                $width = $origHeight;
+            } elseif (! $height) {
                 $height = (int) (($width / $origWidth) * $origHeight);
-            } elseif (null === $width) {
+            } elseif (! $width) {
                 $width = (int) (($height / $origHeight) * $origWidth);
             }
         }


### PR DESCRIPTION
### novactive/ezenhancedimageassetbundle

Fix
> round(): Argument #1 ($num) must be of type int|float, string given
in /var/www/html/ibexa/vendor/imagine/imagine/src/Image/Box.php:42

| Q             | A
| ------------- | ---
| Branch?       | fix-round-Argument1-must-be-of-type-int-float-in-Box42
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating documentation/CHANGELOG.md files -->
| BC breaks?    | no
| Fixed tickets | [#115220 - [MIG-IBEXA] Problème indexation des contenus dans Algolia](https://almaviacx.easyredmine.com/issues/115220)

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
