### PR TITLE
Fix round(): Argument #1 ($num) must be of type int|float, string given

### DIFF
--- a/components/EnhancedImageAssetBundle/src/lib/Imagine/Filter/Loader/PlaceholderFilterLoader.php
+++ b/components/EnhancedImageAssetBundle/src/lib/Imagine/Filter/Loader/PlaceholderFilterLoader.php
@@ -32,11 +32,17 @@ class PlaceholderFilterLoader implements LoaderInterface
         $origWidth = $size->getWidth();
         $origHeight = $size->getHeight();
 
-        if (null === $width || null === $height) {
-            if (null === $height) {
-                $height = (int) (($width / $origWidth) * $origHeight);
-            } elseif (null === $width) {
-                $width = (int) (($height / $origHeight) * $origWidth);
+        if (! $width || ! $height) {
+            // In /var/www/html/ibexa/vendor/imagine/imagine/src/Image/Box.php:42
+            // [TypeError]
+            // round(): Argument #1 ($num) must be of type int|float, string given
+            if (!$height && !$width) {
+                $height = $origWidth;
+                $width = $origHeight;
+            } elseif (!$height) {
+                $height = (int)(($width / $origWidth) * $origHeight);
+            } elseif (!$width) {
+                $width = (int)(($height / $origHeight) * $origWidth);
             }
         }
 


### PR DESCRIPTION
### novactive/ezenhancedimageassetbundle

Fix
> round(): Argument #1 ($num) must be of type int|float, string given
in /var/www/html/ibexa/vendor/imagine/imagine/src/Image/Box.php:42

| Q             | A
| ------------- | ---
| Branch?       | fix-round-Argument1-must-be-of-type-int-float-in-Box42
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating documentation/CHANGELOG.md files -->
| BC breaks?    | no
| Fixed tickets | [#115220 - [MIG-IBEXA] Problème indexation des contenus dans Algolia](https://almaviacx.easyredmine.com/issues/115220)

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
