### PR TITLE
Compatibility with Ibexa 4.6 in MetaNameSchema

### DIFF
--- a/components/SEOBundle/bundle/Core/MetaNameSchema.php
+++ b/components/SEOBundle/bundle/Core/MetaNameSchema.php
@@ -67,7 +67,7 @@ class MetaNameSchema extends NameSchemaService
     /**
      * @var FieldTypeRegistry
      */
-    protected $fieldTypeRegistry;
+    protected FieldTypeRegistry $fieldTypeRegistry;
 
     /**
      * @var RelationListType


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | N/A

Hi,

this adds a property typehint in order to allow running on Ibexa 4.6. I realize that the whole class and/or package should add typehints for consistency, but I think that the priority is getting the bundle running on Ibexa 4.6 without crashing, and then as the time goes fix any found issues.

Thanks!