### PR TITLE
Fix Error "round(): Argument #1 ($num) must be of type int|float, string given"

### DIFF
--- a/components/EnhancedImageAssetBundle/src/lib/FocusPoint/FocusPointCalculator.php
+++ b/components/EnhancedImageAssetBundle/src/lib/FocusPoint/FocusPointCalculator.php
@@ -101,6 +101,10 @@ class FocusPointCalculator
         $width = $options['size'][0] ?? null;
         $height = $options['size'][1] ?? null;
 
+        if (!$width && !$height) {
+            return null;
+        }
+
         $origWidth = $imageSize->getWidth();
         $origHeight = $imageSize->getHeight();
 

--- a/components/EnhancedImageAssetBundle/src/lib/Imagine/Filter/Loader/PlaceholderFilterLoader.php
+++ b/components/EnhancedImageAssetBundle/src/lib/Imagine/Filter/Loader/PlaceholderFilterLoader.php
@@ -40,9 +40,11 @@ class PlaceholderFilterLoader implements LoaderInterface
             }
         }
 
-        if ($origWidth > $width || $origHeight > $height) {
-            $filter = new Thumbnail(new Box($width, $height), ImageInterface::THUMBNAIL_OUTBOUND);
-            $image = $filter->apply($image);
+        if ($width && $height) {
+            if ($origWidth > $width || $origHeight > $height) {
+                $filter = new Thumbnail(new Box($width, $height), ImageInterface::THUMBNAIL_OUTBOUND);
+                $image = $filter->apply($image);
+            }
         }
 
         $image->strip();


### PR DESCRIPTION
Fix Error "round(): Argument #1 ($num) must be of type int|float, string given"
calculateCropSize() must not return a Box if there is no dimension.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating documentation/CHANGELOG.md files -->
| BC breaks?    | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
