### PR TITLE
Need to fix novaezprotectedcontent:cleantoken command

### DIFF
--- a/components/ProtectedContentBundle/bundle/Command/CleanTokenCommand.php
+++ b/components/ProtectedContentBundle/bundle/Command/CleanTokenCommand.php
@@ -24,10 +24,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class CleanTokenCommand extends Command
 {
-    /**
-     * @var EntityManagerInterface
-     */
-    private $entityManager;
+    private EntityManagerInterface $entityManager;
 
     public function __construct(EntityManagerInterface $entityManager)
     {
@@ -45,7 +42,7 @@ class CleanTokenCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 
@@ -62,5 +59,6 @@ class CleanTokenCommand extends Command
 
         $io->success(sprintf('%d entities deleted', count($entities)));
         $io->success('Done.');
+        return Command::SUCCESS;
     }
 }

--- a/components/ProtectedContentBundle/bundle/Repository/EntityRepository.php
+++ b/components/ProtectedContentBundle/bundle/Repository/EntityRepository.php
@@ -27,7 +27,8 @@ abstract class EntityRepository extends ServiceEntityRepository
     // Novactive\Bundle\eZProtectedContentBundle\Repository\EntityRepository::__construct():
     // Argument #1 ($registry) must be of type Doctrine\Persistence\ManagerRegistry,
     // Doctrine\ORM\EntityManager given,
-    // called in /var/www/html/ibexa/vendor/doctrine/orm/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php on line 55
+    // called in
+    // /var/www/html/ibexa/vendor/doctrine/orm/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php on line 55
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, $this->getEntityClass());

--- a/components/ProtectedContentBundle/bundle/Repository/EntityRepository.php
+++ b/components/ProtectedContentBundle/bundle/Repository/EntityRepository.php
@@ -23,6 +23,11 @@ abstract class EntityRepository extends ServiceEntityRepository
 {
     abstract protected function getAlias(): string;
 
+    // Problème :
+    // Novactive\Bundle\eZProtectedContentBundle\Repository\EntityRepository::__construct():
+    // Argument #1 ($registry) must be of type Doctrine\Persistence\ManagerRegistry,
+    // Doctrine\ORM\EntityManager given,
+    // called in /var/www/html/ibexa/vendor/doctrine/orm/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php on line 55
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, $this->getEntityClass());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | feat-108625-ibexa-4-form-mail-protection
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating documentation/CHANGELOG.md files -->
| BC breaks?    | no
| Fixed tickets | #118894

when executing `php bin/console novaezprotectedcontent:cleantoken`

> In EntityRepository.php line 26:
>                                                                                                                                                                                                                                                                                                                
>   [TypeError]                                                                                                                                                                                                                                                                                                  
>   Novactive\Bundle\eZProtectedContentBundle\Repository\EntityRepository::__construct(): Argument #1 ($registry) must be of type Doctrine\Persistence\ManagerRegistry, Doctrine\ORM\EntityManager given, called in /var/www/html/ibexa/vendor/doctrine/orm/lib/Doctrine/ORM/Repository/DefaultRepositoryFactor  
>   y.php on line 55                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                               

