### PR TITLE
doc: display_images_in_sitemap

### DIFF
--- a/components/SEOBundle/documentation/USAGE.md
+++ b/components/SEOBundle/documentation/USAGE.md
@@ -141,6 +141,16 @@ nova_ezseo:
                 contentTypeIdentifiers: ['footer','something']
 ```
 
+Set "display_images_in_sitemap" to true to inject the image tags.
+Notice: this doesn't work with `limit_to_rootlocation: true`.
+
+```yml
+nova_ezseo:
+    system:
+        default:
+            display_images_in_sitemap: true
+```
+
 You can customize label by siteaccess
 ```yml
 novactive.novaseobundle.default.meta_field_name: Metas


### PR DESCRIPTION
Add documentation about display_images_in_sitemap.

**Notice:** display images doesn't work because of the [bug in ibexa](https://issues.ibexa.co/browse/IBX-8292)

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | no
