### PR TITLE
feat: make releaser user remote branch instead of local refs

### DIFF
--- a/src/Command/SyncCommand.php
+++ b/src/Command/SyncCommand.php
@@ -48,7 +48,7 @@ final class SyncCommand extends Command
         );
 
         $answer = $io->ask(
-            "Synchronize <fg=yellow>{$branch}</> accross the specified component. Continue?"
+            "Synchronize <fg=yellow>origin/{$branch}</> accross the specified component. Continue?"
         );
 
         if ('yes' !== $answer) {

--- a/src/Core/Splitter.php
+++ b/src/Core/Splitter.php
@@ -18,8 +18,9 @@ final class Splitter
     {
         $localBranchName = uniqid("{$component}-{$branch}-", false);
         $commands = [
+            ['git', 'fetch', 'origin'],
             [
-                'splitsh-lite', "--prefix=components/{$component}", "--origin=refs/heads/{$branch}",
+                'splitsh-lite', "--prefix=components/{$component}", "--origin=origin/{$branch}",
                 "--target=refs/heads/{$localBranchName}",
             ],
             ['git', 'remote', 'add', $component, "git@github.com:{$component->getRepo()}.git"],

--- a/src/Core/Tagger.php
+++ b/src/Core/Tagger.php
@@ -18,8 +18,9 @@ final class Tagger
     {
         $localBranchName = uniqid("{$component}-{$branch}-", false);
         $commands = [
+            ['git', 'fetch', 'origin'],
             [
-                'splitsh-lite', "--prefix=components/{$component}", "--origin=refs/heads/{$branch}",
+                'splitsh-lite', "--prefix=components/{$component}", "--origin=origin/{$branch}",
                 "--target=refs/heads/{$localBranchName}",
             ],
             ['git', 'remote', 'add', $component, "git@github.com:{$component->getRepo()}.git"],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

When you have too much git refs locally, git will packed them to prevent performance issue.
This will create issue for the releaser script as the local refs are not here anymore.
This is why i decided to change the script to use remote branches instead of local refs
