### PR TITLE
fix: issue with filter tag removing `(` `)` from value

### DIFF
--- a/components/SolrSearchExtraBundle/src/lib/Query/Content/CriterionVisitor/FilterTag.php
+++ b/components/SolrSearchExtraBundle/src/lib/Query/Content/CriterionVisitor/FilterTag.php
@@ -26,7 +26,8 @@ class FilterTag extends BaseVisitor
      */
     public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null): string
     {
-        $stringQuery = strtr($subVisitor->visit($criterion->criterion), ['(' => '', ')' => '']);
+        $stringQuery = $subVisitor->visit($criterion->criterion);
+        $stringQuery = trim($stringQuery, '()');
 
         return '{!tag='.$criterion->tag.'}('.$stringQuery.')';
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating documentation/CHANGELOG.md files -->
| BC breaks?    | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
