### PR TITLE
fix Ibexa 4.6 version in CI as later skeleton require PHP > 8.1

### DIFF
--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -43,7 +43,7 @@ jobs:
         strategy:
             matrix:
                 include:
-                    -   ibexa_version: 4.*
+                    -   ibexa_version: 4.6.7
                         php: 8.1
                         node: 18.x
                     -   ibexa_version: 4.5.*


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no <!-- don't forget updating documentation/CHANGELOG.md files -->
| BC breaks?    | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
