### PR TITLE
Fix Sury for ddev version v1.25.3

### DIFF
--- a/.ddev/web-build/Dockerfile
+++ b/.ddev/web-build/Dockerfile
@@ -1,8 +1,4 @@
-RUN apt-get -y install lsb-release ca-certificates curl && \
-    curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
-    dpkg -i /tmp/debsuryorg-archive-keyring.deb && \
-    sh -c 'echo "deb [signed-by=/usr/share/keyrings/debsuryorg-archive-keyring.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list' && \
-    apt-get update
+# .ddev/web-build/Dockerfile
 
 RUN sudo install -d -m 0755 /etc/apt/keyrings && \
     wget -q https://packages.mozilla.org/apt/repo-signing-key.gpg -O- | sudo tee /etc/apt/keyrings/packages.mozilla.org.asc > /dev/null && \


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | yes
| New feature?  | yes <!-- don't forget updating documentation/CHANGELOG.md files -->
| BC breaks?    | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->

Dans l’image DDEV actuelle (ddev-webserver:v1.25.3, basée sur Debian Trixie), le dépôt Sury est déjà configuré avec : /usr/share/keyrings/deb.sury.org-php.gpg

> E: Conflicting values set for option Signed-By regarding source
    https://packages.sury.org/php/ trixie:
     /usr/share/keyrings/debsuryorg-archive-keyring.gpg
     !=
     /usr/share/keyrings/deb.sury.org-php.gpg

APT voit donc le même repository configuré deux fois avec deux signed-by différents, et refuse de continuer.